### PR TITLE
release: package relocatable Linux SYCL archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Binary release
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/release.yml
+      - CMakeLists.txt
+      - cmake/**
+      - ci/release/**
+      - keygen-rs/**
+      - src/**
+      - tools/**
+      - contrib/**
+      - scripts/build-release.sh
+      - scripts/test/release.py
+  push:
+    tags: ['v*', '!v*-cuda-only']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linux-sycl:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - gpu: nvidia
+            image: docker.io/nvidia/cuda:12.9.1-devel-ubuntu24.04
+            llvm: 20
+          - gpu: amd
+            image: docker.io/rocm/dev-ubuntu-24.04:6.2-complete
+            llvm: 18
+          - gpu: intel
+            image: docker.io/library/ubuntu:24.04
+            llvm: 20
+    env:
+      RELEASE_GPU: ${{ matrix.gpu }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build release image
+        run: |
+          docker build -t xchplot2-release -f ci/release/Containerfile ci/release \
+            --build-arg GPU="$RELEASE_GPU" \
+            --build-arg LLVM_VERSION='${{ matrix.llvm }}' \
+            --build-arg BASE_DEVEL='${{ matrix.image }}'
+      - name: Build and package
+        env:
+          RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
+        run: |
+          docker run --rm -e RELEASE_TAG -v "$PWD:/src" xchplot2-release \
+            bash scripts/build-release.sh
+      - name: Check the extracted runtime and CPU proofs
+        run: |
+          docker run --rm -e RELEASE_GPU -e DEBIAN_FRONTEND=noninteractive \
+            -v "$PWD:/src:ro" -w /src ubuntu:24.04 bash -euc '
+            apt-get update
+            apt-get install -y --no-install-recommends \
+              python3 libstdc++6 libnuma1 libelf1t64 libdrm2 libdrm-amdgpu1
+            python3 scripts/test/release.py build/release-"$RELEASE_GPU"/dist/*.tar.gz \
+              --sycl-probe build/release-"$RELEASE_GPU"/tools/sanity/hellosycl
+          '
+      - uses: actions/upload-artifact@v7
+        with:
+          name: linux-x86_64-sycl-${{ matrix.gpu }}
+          path: |
+            build/release-${{ matrix.gpu }}/dist/*.tar.gz
+            build/release-${{ matrix.gpu }}/dist/*.sha256
+          if-no-files-found: error
+
+  draft:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: linux-sycl
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: linux-x86_64-sycl-*
+          merge-multiple: true
+          path: dist
+      - name: Attach archives to a draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$RELEASE_TAG" dist/* \
+            --verify-tag --draft --title "$RELEASE_TAG" --generate-notes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ if(XCHPLOT2_BUILD_CUDA)
             foreach(_a IN LISTS CMAKE_CUDA_ARCHITECTURES)
                 # Strip sm_ / compute_ prefixes some users pass through
                 string(REGEX REPLACE "^(sm_|compute_)" "" _a "${_a}")
+                string(REGEX REPLACE "-(real|virtual)$" "" _a "${_a}")
                 if(_a MATCHES "^[0-9]+$" AND _a LESS _min_arch)
                     set(_min_arch ${_a})
                 endif()
@@ -1785,3 +1786,9 @@ foreach(_target IN LISTS _xchplot2_targets)
         endif()
     endif()
 endforeach()
+
+# Archive packaging is opt-in; ordinary builds need no release tooling.
+option(XCHPLOT2_PACKAGE "Configure binary release packaging" OFF)
+if(XCHPLOT2_PACKAGE)
+    include(cmake/Packaging.cmake)
+endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,41 @@ When moving sections, update incoming links and keep the useful README
 entry headings. `docs/` is ignored local material; do not publish it as part
 of a documentation move.
 
+## Binary releases
+
+The release workflow builds one Linux archive per GPU vendor through the
+standalone CMake executable and CPack. Build images pin Ubuntu 24.04,
+AdaptiveCpp 25.10, and Rust 1.98.1. NVIDIA uses CUDA 12.9.1 and LLVM 20;
+AMD follows the existing ROCm 6.2 / LLVM 18 pairing; Intel uses LLVM 20 and
+Level Zero. Keep `INSTALL.md` and the archive README in sync with these pins.
+
+For example, build the Intel archive locally:
+
+```bash
+podman build -t xchplot2-release-intel -f ci/release/Containerfile ci/release
+podman run --rm -v "$PWD:/src" xchplot2-release-intel bash scripts/build-release.sh
+```
+
+Use the workflow's build arguments for AMD or NVIDIA. Artifacts are written
+to `build/release-VENDOR/dist/`. `acpp --acpp-deploy` collects runtime and
+JIT dependencies; the build script adds Level Zero, checks the selected
+backend, collects license notices, and makes library paths relative.
+
+PR and manual runs retain workflow artifacts. A `vVERSION` tag creates a
+draft GitHub release; publish it after qualifying the extracted archives on
+the supported GPUs. Do not rebuild between qualification and publication.
+The workflow checks extraction, the packaged SYCL JIT through `hellosycl`,
+CPU plotting, and full proofs in an image without development toolchains.
+
+Run `scripts/test/release.py ARCHIVE.tar.gz` for the archive and CPU checks.
+Add `--sycl-probe build/release-VENDOR/tools/sanity/hellosycl` to test the JIT.
+For GPU qualification, use the extracted executable for the k=22/k=28 byte
+comparisons, full proofs, tiers, spill, and recovery checks described above.
+`gpu-ci.py --binary /path/to/extracted/bin/xchplot2` retains the matching
+build's parity and inventory tools. Build and package must have the same
+source revision and toolchain. Record qualification in release notes; keep
+plots and detailed logs out of the tree.
+
 ## Commit style
 
 Short imperative subjects, lowercase scope prefix, no trailing period:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -406,3 +406,36 @@ Native Windows plotting is outside the current hardware test set.
 Native Windows SYCL is not supported by the current `main` build. Its
 AdaptiveCpp setup and host code require Linux/POSIX facilities; the earlier
 unvalidated source-build outline was not a tested installation path.
+
+### Native AMD and Intel evaluation
+
+The Linux archives pin AdaptiveCpp 25.10. Its
+[installation guide](https://github.com/AdaptiveCpp/AdaptiveCpp/blob/v25.10.0/doc/installing.md)
+describes Windows CPU/CUDA support through an LLVM-integrated build using
+LLVM 18 or newer. Its
+[Windows build workflow](https://github.com/AdaptiveCpp/AdaptiveCpp/blob/v25.10.0/.github/workflows/windows-acppllvm.yml)
+tests that CUDA toolchain. This does not establish Windows HIP or Level Zero
+support for xchplot2. Nightly binaries from `develop` are a separate toolchain
+candidate, not the pinned release compiler.
+
+| Backend | Work required before a native Windows release |
+|---|---|
+| AMD HIP | Qualify an AdaptiveCpp Windows build with the selected HIP SDK and GPU; port the driver-backed `hipMemGetInfo` query and package the matching redistributable runtime. |
+| Intel | Qualify Level Zero or OpenCL with the Windows driver, including device/shared allocations, integer atomics, sorting, and JIT compilation; provide a free-memory query for that backend. |
+
+AMD's [Windows HIP SDK component matrix](https://rocm.docs.amd.com/projects/install-on-windows/en/latest/conceptual/component-support.html)
+differs from Linux ROCm. A Linux ROCm installation or a successful Linux
+archive build does not qualify the corresponding Windows combination.
+
+The project's HIP and Level Zero probes in `src/host/GpuBufferPool.cpp`
+currently use POSIX dynamic loading and are excluded on Windows. OpenCL has
+no free-memory probe. Admission deliberately rejects an unverified GPU
+budget; reporting device capacity as free memory would weaken that check.
+The native CUDA host/file port also needs to be carried into the SYCL build,
+with a matching MSVC/Rust runtime and Windows DLL deployment.
+
+Before adding a Windows SYCL archive, run the existing allocation and kernel
+parity checks, then k=22/k=28 CPU byte comparisons, full proofs, every fitting
+tier and disk-spill variant, memory-pressure rejection, cancellation, and
+recovery using the extracted package on Windows hardware. A native Windows
+AMD/Intel compiler build and GPU run have not yet been qualified.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,9 +14,34 @@ CUDA build, use the [`cuda-only` installation guide](https://github.com/Jsewill/
 
 | Path | Use it for |
 |---|---|
+| [Binary archives](#binary-archives) | Prebuilt CLI and runtime for one GPU vendor |
 | [Container](#container) | Toolchains inside the image; GPU driver and container engine on the host |
 | [Native install](#native-install) | System dependencies and AdaptiveCpp installed by the existing script |
 | [Manual dependencies](#manual-dependencies) | An existing toolchain or a development setup |
+
+## Binary archives
+
+Download the Linux x86-64 `sycl-nvidia`, `sycl-amd`, or `sycl-intel` archive
+and its `.sha256` file from [GitHub Releases](https://github.com/Jsewill/xchplot2/releases).
+Check `sha256sum -c ARCHIVE.tar.gz.sha256`, then extract the archive and run
+`./bin/xchplot2 devices` from its directory. Keep `bin/` and `lib/` together;
+add that `bin` directory to `PATH` to run the CLI elsewhere.
+
+These archives target glibc 2.39+ (Ubuntu 24.04 or a compatible system), an
+x86-64 CPU with AES, SSSE3, and SSE4.1, and a compatible GPU driver. On Ubuntu,
+install `libstdc++6`, `libnuma1`, and `libelf1t64`; AMD also needs `libdrm2`
+and `libdrm-amdgpu1`. The archive includes AdaptiveCpp, LLVM, and one GPU
+backend. No development toolkit is needed. Mixed-vendor builds use the
+source or container instructions below.
+
+The NVIDIA bundle uses CUDA 12.9.1; driver 575.57.08+ is recommended. The AMD
+bundle uses ROCm 6.2 and supports hardware covered by that runtime. The Intel
+bundle uses Level Zero and requires the Intel GPU compute driver. See
+[troubleshooting](REFERENCE.md#troubleshooting) for the tested Intel driver
+settings and the release notes for hardware qualification.
+
+`BUILDINFO.txt` records source and toolchain revisions; `licenses/` contains
+dependency notices. Releases without binary assets require a source build.
 
 ## Container
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -287,9 +287,8 @@ Toolchain prerequisites for the NVIDIA build:
   link, plus C++20 CUDA dialect, both require 12.0).
 - **CMake ≥ 3.26** for nvcc 12.5+ (Debian 12's stock 3.25 doesn't know
   the dialect flags; install Kitware's repo).
-- **rustc ≥ 1.85** (rustup `stable`). Distro-packaged Rust (Ubuntu
-  24.04 apt cargo is 1.75) is too old for the `edition2024` feature
-  required by `chia-client` 0.42.
+- **Rust via rustup `stable`**. Release builds use Rust 1.98.1.
+  Older distro-packaged Rust may not support the locked dependencies.
 
 ### NVIDIA dependency sources
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ grouping, may require replotting.
 
 ## Quick start
 
+For prebuilt archives, follow [binary installation](INSTALL.md#binary-archives).
+
 Install the [build dependencies](INSTALL.md#native-install) first.
 For containers or Windows, follow [INSTALL.md](INSTALL.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ xchplot2 is a client-side plot builder. It handles:
   or reused seed lets an attacker who observes plot IDs correlate
   plots to the same master key.
 - BLS key parsing via the
-  [`chia` Rust crate](https://crates.io/crates/chia) through
+  [`chia-bls` Rust crate](https://crates.io/crates/chia-bls) through
   `keygen-rs`.
 - Per-plot private keys, included in plot memos and saved job manifests.
 - Large file writes into caller-supplied output directories.

--- a/_typos.toml
+++ b/_typos.toml
@@ -15,3 +15,5 @@ nd = "nd"
 hge = "hge"
 # Yann Collet, author of LZ4 / zstd, attributed in NOTICE.
 Collet = "Collet"
+# POSIX / Windows CRT file-open mode.
+WRONLY = "WRONLY"

--- a/ci/release/Containerfile
+++ b/ci/release/Containerfile
@@ -1,0 +1,54 @@
+# Build tools for the relocatable SYCL archives. See the release workflow for bases.
+ARG BASE_DEVEL=docker.io/library/ubuntu:24.04
+FROM ${BASE_DEVEL}
+ARG GPU=intel
+ARG LLVM_VERSION=20
+ENV DEBIAN_FRONTEND=noninteractive
+ENV CMAKE_BUILD_PARALLEL_LEVEL=2
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential ca-certificates curl git ninja-build cmake python3 patchelf \
+        libboost-context-dev libnuma-dev llvm-${LLVM_VERSION} llvm-${LLVM_VERSION}-dev clang-${LLVM_VERSION} \
+        libclang-${LLVM_VERSION}-dev libclang-cpp${LLVM_VERSION}-dev lld-${LLVM_VERSION} \
+        libomp-${LLVM_VERSION}-dev libclang-rt-${LLVM_VERSION}-dev \
+    && if [ "$GPU" = intel ]; then apt-get install -y --no-install-recommends libze-dev; fi \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl --proto '=https' --tlsv1.2 -sSfL --retry 5 --retry-all-errors \
+        https://sh.rustup.rs -o /tmp/rustup-init.sh \
+    && sh /tmp/rustup-init.sh -y --default-toolchain 1.98.1 --profile minimal \
+    && rm /tmp/rustup-init.sh
+ENV PATH=/root/.cargo/bin:/opt/adaptivecpp/bin:${PATH}
+RUN cargo install --locked --features cli cargo-about --version 0.9.2
+RUN git clone --depth 1 --branch v25.10.0 \
+        https://github.com/AdaptiveCpp/AdaptiveCpp.git /tmp/acpp-src \
+    && case "$GPU" in \
+        nvidia) backend_flags='-DWITH_CUDA_BACKEND=ON -DWITH_ROCM_BACKEND=OFF -DWITH_LEVEL_ZERO_BACKEND=OFF -DCUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda' ;; \
+        amd) backend_flags='-DWITH_CUDA_BACKEND=OFF -DWITH_ROCM_BACKEND=ON -DWITH_LEVEL_ZERO_BACKEND=OFF -DROCM_PATH=/opt/rocm -DROCM_DEVICE_LIBS_PATH=/opt/rocm/amdgcn/bitcode' ;; \
+        intel) backend_flags='-DWITH_CUDA_BACKEND=OFF -DWITH_ROCM_BACKEND=OFF -DWITH_LEVEL_ZERO_BACKEND=ON' ;; \
+        *) exit 1 ;; \
+       esac \
+    && cmake -S /tmp/acpp-src -B /tmp/acpp-build -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/opt/adaptivecpp \
+        -DCMAKE_C_COMPILER=/usr/lib/llvm-${LLVM_VERSION}/bin/clang \
+        -DCMAKE_CXX_COMPILER=/usr/lib/llvm-${LLVM_VERSION}/bin/clang++ \
+        -DLLVM_DIR=/usr/lib/llvm-${LLVM_VERSION}/lib/cmake/llvm \
+        -DClang_DIR=/usr/lib/llvm-${LLVM_VERSION}/lib/cmake/clang \
+        -DACPP_LLD_PATH=/usr/lib/llvm-${LLVM_VERSION}/bin/ld.lld \
+        -DCLANG_INCLUDE_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib/clang/${LLVM_VERSION} \
+        -DWITH_OPENCL_BACKEND=OFF -DACPP_SUBPROJECT_PARALLEL_JOBS=2 $backend_flags \
+    && cmake --build /tmp/acpp-build \
+    && cmake --install /tmp/acpp-build \
+    && mkdir -p /opt/release-licenses \
+    && cp /tmp/acpp-src/LICENSE /opt/release-licenses/adaptivecpp.txt \
+    && git -C /tmp/acpp-src rev-parse HEAD > /opt/release-licenses/adaptivecpp-revision.txt \
+    && if [ "$GPU" = intel ]; then \
+        cmake --build /tmp/acpp-build --target InstallLLVMSpirvTranslator \
+        && translator=$(find /tmp/acpp-build -type d -name LLVMSpirvTranslator) \
+        && cp "$translator/LICENSE.TXT" /opt/release-licenses/llvm-spirv.txt \
+        && git -C "$translator" rev-parse HEAD > /opt/release-licenses/llvm-spirv-revision.txt; \
+       fi \
+    && rm -rf /tmp/acpp-src /tmp/acpp-build
+RUN git config --system --add safe.directory /src
+ENV CMAKE_PREFIX_PATH=/opt/adaptivecpp
+ENV XCHPLOT2_RELEASE_GPU=${GPU}
+ENV XCHPLOT2_RELEASE_LLVM=${LLVM_VERSION}
+WORKDIR /src

--- a/ci/release/README.txt
+++ b/ci/release/README.txt
@@ -1,0 +1,29 @@
+xchplot2 — SYCL/AdaptiveCpp binary
+
+Choose the archive for your GPU: sycl-nvidia, sycl-amd, or sycl-intel.
+Keep bin/ and lib/ together when moving the extracted directory.
+Run ./bin/xchplot2 --help or ./bin/xchplot2 devices from that directory.
+
+Requirements:
+  Linux x86_64 with glibc 2.39+ (Ubuntu 24.04 or a compatible system).
+  CPU with AES, SSSE3, and SSE4.1 instructions.
+  Standard OS libraries and a compatible GPU driver.
+
+On Ubuntu 24.04, install the OS libraries with:
+  sudo apt install libstdc++6 libnuma1 libelf1t64
+
+NVIDIA: Maxwell or newer; driver 575.57.08+ recommended for CUDA 12.9.1.
+AMD: hardware supported by the bundled ROCm 6.2 runtime and a compatible
+amdgpu kernel driver; libdrm2 and libdrm-amdgpu1 must be installed.
+Intel: an Intel GPU compute driver providing libze_intel_gpu.so.1.
+Consult the release notes for tested hardware and driver versions.
+
+AdaptiveCpp, LLVM, and the selected backend runtime are included under lib/.
+No CUDA, ROCm, LLVM, or AdaptiveCpp development installation is needed.
+BUILDINFO.txt records the source and toolchain revisions. Dependency licenses
+are under licenses/. GPU drivers and core OS libraries are not bundled.
+
+Usage: https://github.com/Jsewill/xchplot2
+Installation: https://github.com/Jsewill/xchplot2/blob/main/INSTALL.md
+Intel settings: https://github.com/Jsewill/xchplot2/blob/main/REFERENCE.md#troubleshooting
+Report issues: https://github.com/Jsewill/xchplot2/issues

--- a/ci/release/licenses.hbs
+++ b/ci/release/licenses.hbs
@@ -1,0 +1,11 @@
+Rust dependencies included in xchplot2
+
+{{#each licenses}}
+{{name}}
+{{#each used_by}}
+  {{crate.name}} {{crate.version}}
+{{/each}}
+
+{{{text}}}
+
+{{/each}}

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -1,0 +1,71 @@
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux" OR NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    message(FATAL_ERROR "Binary packaging currently supports Linux x86_64")
+endif()
+if(NOT XCHPLOT2_PACKAGE_GPU MATCHES "^(nvidia|amd|intel)$")
+    message(FATAL_ERROR "XCHPLOT2_PACKAGE_GPU must be nvidia, amd, or intel")
+endif()
+if(NOT EXISTS "${XCHPLOT2_RUNTIME_DIR}/libacpp-rt.so")
+    message(FATAL_ERROR "Collect the AdaptiveCpp runtime first: scripts/build-release.sh")
+endif()
+if(NOT EXISTS "${XCHPLOT2_LICENSE_DIR}/rust.txt")
+    message(FATAL_ERROR "Generate the release licenses first: scripts/build-release.sh")
+endif()
+if(DEFINED ENV{RELEASE_TAG} AND NOT "$ENV{RELEASE_TAG}" STREQUAL ""
+        AND NOT "$ENV{RELEASE_TAG}" STREQUAL "v${PROJECT_VERSION}")
+    message(FATAL_ERROR "Release tag must match v${PROJECT_VERSION}")
+endif()
+
+execute_process(COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE _release_revision OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY)
+execute_process(COMMAND "${GIT_EXECUTABLE}" diff --quiet HEAD --
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" RESULT_VARIABLE _release_dirty)
+if(NOT _release_dirty EQUAL 0)
+    string(APPEND _release_revision "-dirty")
+endif()
+execute_process(COMMAND rustc --version
+    OUTPUT_VARIABLE _release_rust OUTPUT_STRIP_TRAILING_WHITESPACE
+    COMMAND_ERROR_IS_FATAL ANY)
+file(READ "${CMAKE_BINARY_DIR}/runtime-info.txt" _release_runtime)
+set(_release_cuda "")
+if(XCHPLOT2_BUILD_CUDA)
+    set(_release_cuda "CUDA: ${CMAKE_CUDA_COMPILER_VERSION}\nCUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}\n")
+endif()
+file(WRITE "${CMAKE_BINARY_DIR}/BUILDINFO.txt"
+    "xchplot2 ${PROJECT_VERSION}\n"
+    "Backend: SYCL/AdaptiveCpp (${XCHPLOT2_PACKAGE_GPU})\n"
+    "Source: ${_release_revision}\n"
+    "pos2-chip: ${POS2_CHIP_GIT_TAG} (contrib/pos2-solver-candidates.patch applied)\n"
+    "System: ${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR}\n"
+    "C++: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}\n"
+    "SYCL targets: ${ACPP_TARGETS}\n"
+    "${_release_cuda}"
+    "Rust: ${_release_rust}\n"
+    "${_release_runtime}")
+
+set_target_properties(xchplot2 PROPERTIES
+    INSTALL_RPATH "$ORIGIN/../lib" INSTALL_RPATH_USE_LINK_PATH FALSE)
+install(TARGETS xchplot2 RUNTIME DESTINATION bin)
+install(DIRECTORY "${XCHPLOT2_RUNTIME_DIR}/" DESTINATION lib USE_SOURCE_PERMISSIONS)
+install(FILES "${CMAKE_BINARY_DIR}/BUILDINFO.txt" ci/release/README.txt
+    DESTINATION .)
+install(FILES LICENSE DESTINATION licenses)
+install(DIRECTORY "${XCHPLOT2_LICENSE_DIR}/" DESTINATION licenses)
+install(FILES "${POS2_CHIP_DIR}/LICENSE" DESTINATION licenses RENAME pos2-chip.txt)
+install(FILES "${POS2_CHIP_DIR}/lib/fse/LICENSE" DESTINATION licenses RENAME fse.txt)
+file(READ "${POS2_CHIP_DIR}/src/pos/aes/soft_aes.hpp" _aes_source)
+string(REGEX MATCH "^/\\*([^*]|\\*+[^*/])*\\*/" _aes_license "${_aes_source}")
+if(NOT _aes_license)
+    message(FATAL_ERROR "Could not extract the pos2-chip AES license")
+endif()
+file(WRITE "${CMAKE_BINARY_DIR}/aes-license.txt" "${_aes_license}\n")
+install(FILES "${CMAKE_BINARY_DIR}/aes-license.txt" DESTINATION licenses RENAME aes.txt)
+set(CPACK_GENERATOR TGZ)
+set(CPACK_PACKAGE_NAME xchplot2)
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_FILE_NAME "xchplot2-${PROJECT_VERSION}-linux-x86_64-sycl-${XCHPLOT2_PACKAGE_GPU}")
+set(CPACK_PACKAGE_CHECKSUM SHA256)
+set(CPACK_STRIP_FILES ON)
+set(CPACK_SOURCE_GENERATOR "")
+include(CPack)

--- a/keygen-rs/Cargo.lock
+++ b/keygen-rs/Cargo.lock
@@ -9,45 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,12 +19,6 @@ name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
-
-[[package]]
-name = "base64"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -138,12 +93,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
-name = "bytes"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,28 +109,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "chia"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676e3b6f57c1b028bcaedb215109e3c96678d4b41079930aa88f4e130a5f0e1b"
-dependencies = [
- "chia-bls 0.48.0",
- "chia-client",
- "chia-consensus",
- "chia-datalayer",
- "chia-protocol",
- "chia-puzzle-types",
- "chia-secp",
- "chia-serde",
- "chia-sha2 0.48.0",
- "chia-ssl",
- "chia-traits 0.48.0",
- "clvm-traits",
- "clvm-utils",
- "clvmr",
-]
 
 [[package]]
 name = "chia-bls"
@@ -206,82 +133,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e698e6c8cb9ce00f626d810fcbae6ded7fed8806c4b550a5f58e9b7bbee565a9"
 dependencies = [
  "blst",
- "chia-serde",
  "chia-sha2 0.48.0",
  "chia-traits 0.48.0",
  "hex",
  "hkdf",
  "linked-hash-map",
- "serde",
  "sha2 0.10.9",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "chia-client"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001273eef8bc9c4b1c4603d9ae9b231de6acabeb955ba23feadeca0a211a0cb2"
-dependencies = [
- "chia-protocol",
- "chia-traits 0.48.0",
- "futures-util",
- "thiserror 2.0.18",
- "tokio",
- "tokio-tungstenite",
- "tungstenite",
-]
-
-[[package]]
-name = "chia-consensus"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbdfa6fe38f2ffaa6457f6c17a643fe7682126b6b6ac04326c4f45889369604a"
-dependencies = [
- "bitflags",
- "chia-bls 0.48.0",
- "chia-protocol",
- "chia-puzzle-types",
- "chia-puzzles",
- "chia-sha2 0.48.0",
- "chia-traits 0.48.0",
- "chia_streamable_macro 0.48.0",
- "clvm-traits",
- "clvm-utils",
- "clvmr",
- "hex",
- "hex-literal",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "chia-datalayer"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ff5d73fdbd7d69023c0d12c658a3486d128065a844df970013242dad7130a6"
-dependencies = [
- "bitvec",
- "chia-datalayer-macro",
- "chia-protocol",
- "chia-sha2 0.48.0",
- "chia-traits 0.48.0",
- "chia_streamable_macro 0.48.0",
- "indexmap",
- "num-traits",
- "rayon",
- "thiserror 2.0.18",
- "zstd",
-]
-
-[[package]]
-name = "chia-datalayer-macro"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6bc4f3706422ca3f84c76107b9262c5d2cad590e9c96810529fea8d6fa6e03"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -303,7 +161,6 @@ checksum = "23b6b29c18eda3a4b4f882611e2227dde34345778c3e3bd3d3d8d84354b30208"
 dependencies = [
  "chia-bls 0.48.0",
  "chia-pos2",
- "chia-serde",
  "chia-sha2 0.48.0",
  "chia-traits 0.48.0",
  "chia_streamable_macro 0.48.0",
@@ -311,57 +168,6 @@ dependencies = [
  "clvm-utils",
  "clvmr",
  "hex",
- "serde",
- "serde_arrays",
-]
-
-[[package]]
-name = "chia-puzzle-types"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8247ccae54f944c37adad740fb4a552fda0bab7f3f1f35e32c7ecf7b5dddb1b3"
-dependencies = [
- "chia-bls 0.48.0",
- "chia-protocol",
- "chia-puzzles",
- "chia-sha2 0.48.0",
- "clvm-traits",
- "clvm-utils",
- "clvmr",
- "hex-literal",
- "num-bigint",
-]
-
-[[package]]
-name = "chia-puzzles"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "553363ce9550cfde0ae1306a0a79bf9afd36ea09e0222b874b6287b44ad9d178"
-dependencies = [
- "hex",
- "hex-literal",
-]
-
-[[package]]
-name = "chia-secp"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edfac9a0e1aa3121f5e9e53638eee650de4c0db2820f81e77e2c2f19a4ab087"
-dependencies = [
- "chia-sha2 0.48.0",
- "hex",
- "k256",
- "p256",
-]
-
-[[package]]
-name = "chia-serde"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0199bf6ebf466516f033aa5fb89e414a0121a8c93c4a8225c1e4b78abe18f7"
-dependencies = [
- "hex",
- "serde",
 ]
 
 [[package]]
@@ -380,19 +186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee35326425aed01e8663dc684dc481e874faa765310053f1a65588b89f825a6e"
 dependencies = [
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "chia-ssl"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4f21993e0859eb5098fc59cfcd7a42ccad6ab31c983ae68964eaeb164ed9ca"
-dependencies = [
- "getrandom 0.4.2",
- "rcgen",
- "rsa",
- "thiserror 2.0.18",
- "time",
 ]
 
 [[package]]
@@ -458,8 +251,6 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06d7b1b6e7a83e1d4a4864ac34ef3f7933ef87fcd3f2fa2ff09f9d38a19f61af"
 dependencies = [
- "chia-bls 0.48.0",
- "chia-secp",
  "clvm-derive",
  "clvmr",
  "num-bigint",
@@ -542,31 +333,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crypto-bigint"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,7 +344,6 @@ dependencies = [
  "hybrid-array",
  "num-traits",
  "rand_core 0.10.1",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -605,17 +370,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-primes"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f41f23de7d24cdbda7f0c4d9c0351f99a4ceb258ef30e5c1927af8987ffe5a"
-dependencies = [
- "crypto-bigint",
- "libm",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,12 +380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
-
-[[package]]
 name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,29 +388,6 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
-]
-
-[[package]]
-name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
 ]
 
 [[package]]
@@ -686,17 +411,6 @@ dependencies = [
  "const-oid",
  "crypto-common 0.2.1",
  "ctutils",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -782,49 +496,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -832,17 +503,6 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -962,22 +622,6 @@ checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.2",
 ]
-
-[[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
-dependencies = [
- "bytes",
- "itoa",
-]
-
-[[package]]
-name = "httparse"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
@@ -1137,33 +781,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "mio"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,12 +789,6 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1208,15 +819,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,38 +844,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
-]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkcs1"
-version = "0.8.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986d2e952779af96ea048f160fd9194e1751b4faea78bcf3ceb456efe008088e"
-dependencies = [
- "der",
- "spki",
 ]
 
 [[package]]
@@ -1287,26 +863,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
 name = "pos2_keygen"
 version = "0.1.0"
 dependencies = [
  "bech32",
- "chia",
+ "chia-bls 0.48.0",
+ "chia-protocol",
  "hex",
  "sha2 0.11.0",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1436,40 +1001,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "rcgen"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
-dependencies = [
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "x509-parser",
- "yasna",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,56 +1008,6 @@ checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
  "crypto-bigint",
  "hmac 0.13.0",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.17",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.10.0-rc.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b2aa4ba0d89f73d1e332df05be0eeab8840351c36ca5654341dfdb57bb3caf"
-dependencies = [
- "const-oid",
- "crypto-bigint",
- "crypto-primes",
- "digest 0.11.2",
- "pkcs1",
- "pkcs8",
- "rand_core 0.10.1",
- "signature",
- "spki",
- "zeroize",
-]
-
-[[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
-dependencies = [
- "zeroize",
 ]
 
 [[package]]
@@ -1579,15 +1060,6 @@ name = "serde-big-array"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_arrays"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a16b99c5ea4fe3daccd14853ad260ec00ea043b2708d1fd1da3106dcd8d9df"
 dependencies = [
  "serde",
 ]
@@ -1695,22 +1167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "spki"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,17 +1191,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1804,63 +1249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
-dependencies = [
- "deranged",
- "itoa",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
-
-[[package]]
-name = "time-macros"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
-name = "tokio"
-version = "1.52.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,23 +1263,6 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -1913,28 +1284,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1997,94 +1350,6 @@ dependencies = [
  "bytemuck",
  "safe_arch",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2204,33 +1469,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "ring",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "yasna"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
-dependencies = [
- "time",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2275,31 +1513,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/keygen-rs/Cargo.toml
+++ b/keygen-rs/Cargo.toml
@@ -2,17 +2,19 @@
 name = "pos2_keygen"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 publish = false
 
 [lib]
 crate-type = ["staticlib"]
 
 [dependencies]
-chia = "0.48"
+chia-bls = "0.48"
 bech32 = "0.12"
 sha2 = "0.11"
 
 [dev-dependencies]
+chia-protocol = "0.48"
 hex = "0.4"
 
 [profile.release]

--- a/keygen-rs/about.toml
+++ b/keygen-rs/about.toml
@@ -1,0 +1,2 @@
+accepted = ["Apache-2.0", "MIT", "BSD-2-Clause", "BSD-3-Clause", "ISC", "Unicode-3.0", "Zlib"]
+ignore-dev-dependencies = true

--- a/keygen-rs/src/lib.rs
+++ b/keygen-rs/src/lib.rs
@@ -1,17 +1,16 @@
-// pos2_keygen — C-callable shim around chia (chia-bls + chia-protocol)
+// pos2_keygen — C-callable shim around chia-bls
 // that derives a v2 plot's plot_id and memo from caller-supplied farmer +
 // pool keys plus a 32-byte master-SK seed. The GPU plotter uses the returned
 // plot_id / memo to drive the existing batch path.
 //
 // The heavy lifting (BLS12-381 arithmetic, EIP-2333 HD derivation, Chia's
-// taproot construction, compute_plot_id_v2 hashing) lives in chia-rs; this
+// taproot construction) uses chia-rs; this
 // crate just sequences the calls and lays out the memo bytes the same way
 // chia-blockchain's create_v2_plots does, so the resulting plots are
 // byte-identical to `chia plots create --v2`.
 
-use chia::bls::{PublicKey, SecretKey};
-use chia::protocol::{compute_plot_id_v2, Bytes32};
-use chia::sha2::Sha256;
+use chia_bls::{PublicKey, SecretKey};
+use sha2::{Digest, Sha256};
 
 // ---------------------------------------------------------------------------
 // Result codes returned across the FFI boundary.
@@ -70,6 +69,27 @@ fn generate_plot_public_key(
     }
 }
 
+// Chia's protocol crate also requires the CLVM runtime. Keep only the plot-ID
+// encoding here and compare it with that crate in tests. Integers in Chia's
+// streamable format are big-endian, unlike the subseed index below.
+fn compute_plot_id_v2(
+    strength: u8,
+    plot_pk: &PublicKey,
+    pool_key: &[u8],
+    plot_index: u16,
+    meta_group: u8,
+) -> [u8; 32] {
+    let mut group = Sha256::new();
+    group.update([strength]);
+    group.update(plot_pk.to_bytes());
+    group.update(pool_key);
+    let mut id = Sha256::new();
+    id.update(group.finalize());
+    id.update(plot_index.to_be_bytes());
+    id.update([meta_group]);
+    id.finalize().into()
+}
+
 /// Derives a v2 plot's plot_id and memo from caller-supplied keys.
 ///
 /// Inputs:
@@ -126,45 +146,34 @@ pub unsafe extern "C" fn pos2_keygen_derive_plot(
         Err(_) => return POS2_BAD_FARMER_PK,
     };
 
-    let (pool_pk_opt, pool_ph_opt, pool_key_slice): (Option<PublicKey>, Option<Bytes32>, &[u8]) =
-        match pool_kind {
-            x if x == POS2_POOL_PK => {
-                let bytes: &[u8; 48] = match unsafe { (pool_key_ptr as *const [u8; 48]).as_ref() } {
-                    Some(b) => b,
-                    None => return POS2_BAD_POOL_KEY,
-                };
-                let pk = match PublicKey::from_bytes(bytes) {
-                    Ok(pk) => pk,
-                    Err(_) => return POS2_BAD_POOL_KEY,
-                };
-                (Some(pk), None, &bytes[..])
+    let (include_taproot, pool_key_slice): (bool, &[u8]) = match pool_kind {
+        x if x == POS2_POOL_PK => {
+            let bytes: &[u8; 48] = match unsafe { (pool_key_ptr as *const [u8; 48]).as_ref() } {
+                Some(b) => b,
+                None => return POS2_BAD_POOL_KEY,
+            };
+            if PublicKey::from_bytes(bytes).is_err() {
+                return POS2_BAD_POOL_KEY;
             }
-            x if x == POS2_POOL_PH => {
-                let bytes: &[u8; 32] = match unsafe { (pool_key_ptr as *const [u8; 32]).as_ref() } {
-                    Some(b) => b,
-                    None => return POS2_BAD_POOL_KEY,
-                };
-                let ph: Bytes32 = (*bytes).into();
-                (None, Some(ph), &bytes[..])
-            }
-            _ => return POS2_BAD_POOL_KIND,
-        };
+            (false, &bytes[..])
+        }
+        x if x == POS2_POOL_PH => {
+            let bytes: &[u8; 32] = match unsafe { (pool_key_ptr as *const [u8; 32]).as_ref() } {
+                Some(b) => b,
+                None => return POS2_BAD_POOL_KEY,
+            };
+            (true, &bytes[..])
+        }
+        _ => return POS2_BAD_POOL_KIND,
+    };
 
     let master_sk = SecretKey::from_seed(seed);
     let local_sk = master_sk_to_local_sk(&master_sk);
     let local_pk = local_sk.public_key();
 
-    let include_taproot = pool_ph_opt.is_some();
     let plot_pk = generate_plot_public_key(&local_pk, &farmer_pk, include_taproot);
 
-    let plot_id: Bytes32 = compute_plot_id_v2(
-        strength,
-        &plot_pk,
-        pool_pk_opt.as_ref(),
-        pool_ph_opt.as_ref(),
-        plot_index,
-        meta_group,
-    );
+    let plot_id = compute_plot_id_v2(strength, &plot_pk, pool_key_slice, plot_index, meta_group);
 
     let master_sk_bytes = master_sk.to_bytes();
     let memo_len = pool_key_slice.len() + 48 /* farmer_pk */ + master_sk_bytes.len();
@@ -176,7 +185,7 @@ pub unsafe extern "C" fn pos2_keygen_derive_plot(
     }
 
     unsafe {
-        std::ptr::copy_nonoverlapping(plot_id.as_ref().as_ptr(), out_plot_id, 32);
+        std::ptr::copy_nonoverlapping(plot_id.as_ptr(), out_plot_id, 32);
         let dst = out_memo_buf;
         std::ptr::copy_nonoverlapping(pool_key_slice.as_ptr(), dst, pool_key_slice.len());
         std::ptr::copy_nonoverlapping(farmer_pk_bytes.as_ptr(), dst.add(pool_key_slice.len()), 48);
@@ -244,7 +253,6 @@ pub unsafe extern "C" fn pos2_keygen_derive_subseed(
     idx: u64,
     out_seed: *mut u8, // 32 bytes
 ) -> i32 {
-    use sha2::{Digest, Sha256};
     if base_seed.is_null() || out_seed.is_null() {
         return POS2_BAD_SEED;
     }
@@ -262,6 +270,35 @@ pub unsafe extern "C" fn pos2_keygen_derive_subseed(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn plot_ids_match_chia_protocol() {
+        let plot_pk = SecretKey::from_seed(&[0x11; 32]).public_key();
+        let pool_pk = SecretKey::from_seed(&[0x22; 32]).public_key();
+        let contract = chia_protocol::Bytes32::new([0x33; 32]);
+        for strength in [1, 2, 32, 63] {
+            for index in [0, 1, 255, 256, u16::MAX] {
+                for group in [0, 1, u8::MAX] {
+                    for pool in [false, true] {
+                        let bytes = pool_pk.to_bytes();
+                        let key: &[u8] = if pool { &bytes } else { contract.as_ref() };
+                        let expected = chia_protocol::compute_plot_id_v2(
+                            strength,
+                            &plot_pk,
+                            pool.then_some(&pool_pk),
+                            (!pool).then_some(&contract),
+                            index,
+                            group,
+                        );
+                        assert_eq!(
+                            compute_plot_id_v2(strength, &plot_pk, key, index, group),
+                            expected.to_bytes()
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     // Same inputs must produce identical plot_id + memo.
     #[test]

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Build a SYCL archive inside ci/release/Containerfile.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+gpu=${XCHPLOT2_RELEASE_GPU:?Run this script in the release build image}
+llvm=${XCHPLOT2_RELEASE_LLVM:-20}
+case "$gpu" in
+    nvidia) backend=cuda; components=core,cuda; build_cuda=ON ;;
+    amd) backend=hip; components=core,hip; build_cuda=OFF ;;
+    intel) backend=ze; components=core; build_cuda=OFF ;;
+    *) echo "Unknown release GPU: $gpu" >&2; exit 1 ;;
+esac
+build_dir=${1:-build/release-$gpu}
+mkdir -p "$build_dir"
+build_dir=$(cd "$build_dir" && pwd)
+runtime="$build_dir/runtime"
+licenses="$build_dir/licenses"
+rm -rf "$runtime" "$licenses"
+mkdir -p "$runtime" "$licenses"
+acpp --acpp-deploy="$components:$runtime"
+cp /opt/release-licenses/*.txt "$licenses/"
+cp /usr/share/doc/libllvm"$llvm"/copyright "$licenses/llvm.txt"
+cp /usr/share/doc/libboost1.83-dev/copyright "$licenses/boost.txt"
+cp /usr/share/common-licenses/Apache-2.0 "$licenses/Apache-2.0.txt"
+# LLVM's distribution libraries have additional ABI-versioned dependencies.
+# Bundle their permissively licensed runtimes so other Linux distributions do
+# not need Ubuntu's particular libxml2/ICU versions installed system-wide.
+for library in libffi.so.8 libedit.so.2 libz.so.1 libzstd.so.1 libxml2.so.2 \
+        libtinfo.so.6 libbsd.so.0 libicuuc.so.74 libicudata.so.74 liblzma.so.5 libmd.so.0; do
+    cp -L /usr/lib/x86_64-linux-gnu/"$library" "$runtime/$library"
+done
+for package in libffi8 libedit2 zlib1g libzstd1 libxml2 libtinfo6 libbsd0 libicu74 liblzma5 libmd0; do
+    cp /usr/share/doc/"$package"/copyright "$licenses/$package.txt"
+done
+printf 'AdaptiveCpp: %s\nLLVM: %s\n' \
+    "$(cat /opt/release-licenses/adaptivecpp-revision.txt)" \
+    "$(/usr/lib/llvm-"$llvm"/bin/llvm-config --version)" > "$build_dir/runtime-info.txt"
+dpkg-query -W -f='${Package}: ${Version}\n' "libllvm$llvm" "libomp5-$llvm" libffi8 libedit2 \
+    zlib1g libzstd1 libxml2 libtinfo6 libbsd0 libicu74 liblzma5 libmd0 >> "$build_dir/runtime-info.txt"
+
+case "$gpu" in
+    nvidia)
+        cp /usr/share/doc/cuda-cudart-12-9/copyright "$licenses/cuda.txt"
+        curl --proto '=https' --tlsv1.2 -sSfL --retry 5 \
+            https://raw.githubusercontent.com/NVIDIA/cccl/v2.8.2/LICENSE \
+            -o "$licenses/cuda-cccl.txt"
+        ;;
+    amd)
+        for component in hip amd_comgr hsa-runtime64 hsakmt rocprofiler-register ROCm-Device-Libs rocm-llvm; do
+            mkdir -p "$licenses/rocm/$component"
+            cp /opt/rocm/share/doc/"$component"/LICENSE* "$licenses/rocm/$component/"
+        done
+        printf 'ROCm: %s\n' "$(cat /opt/rocm/.info/version)" >> "$build_dir/runtime-info.txt"
+        ;;
+    intel)
+        # AdaptiveCpp 25.10 has no Level Zero deployment component.
+        cp /opt/adaptivecpp/lib/hipSYCL/librt-backend-ze.so "$runtime/hipSYCL/"
+        cp /opt/adaptivecpp/lib/hipSYCL/llvm-to-backend/libllvm-to-spirv.so "$runtime/hipSYCL/llvm-to-backend/"
+        cp /opt/adaptivecpp/lib/hipSYCL/bitcode/libkernel-sscp-spirv-full.bc "$runtime/hipSYCL/bitcode/"
+        mkdir -p "$runtime/hipSYCL/ext/llvm-spirv/bin"
+        cp /opt/adaptivecpp/lib/hipSYCL/ext/llvm-spirv/bin/llvm-spirv "$runtime/hipSYCL/ext/llvm-spirv/bin/"
+        cp -P /usr/lib/x86_64-linux-gnu/libze_loader.so* "$runtime/"
+        cp /usr/share/doc/libze1/copyright "$licenses/level-zero.txt"
+        printf 'LLVM-SPIRV: %s\n' "$(cat /opt/release-licenses/llvm-spirv-revision.txt)" >> "$build_dir/runtime-info.txt"
+        dpkg-query -W -f='Level Zero loader: ${Version}\n' libze1 >> "$build_dir/runtime-info.txt"
+        ;;
+esac
+test -f "$runtime/hipSYCL/librt-backend-$backend.so"
+# Core OS libraries remain system prerequisites, including libnuma.
+rm -f "$runtime"/libnuma.so*
+python3 - "$runtime" <<'PY'
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+runtime = Path(sys.argv[1])
+for path in runtime.rglob("*"):
+    if path.is_symlink() or not path.is_file():
+        continue
+    with path.open("rb") as file:
+        if file.read(4) != b"\x7fELF":
+            continue
+    # libcudart only needs system libraries; retain NVIDIA's original binary.
+    if path.name.startswith("libcudart.so"):
+        continue
+    relative = os.path.relpath(runtime, path.parent)
+    root = "$ORIGIN/" + relative
+    subprocess.run(["patchelf", "--set-rpath",
+                    "$ORIGIN:" + root + ":" + root + "/hipSYCL/llvm-to-backend", path], check=True)
+PY
+
+rust_docs="$(rustc --print sysroot)/share/doc/rust"
+mkdir -p "$licenses/rust-standard-library"
+cp "$rust_docs/COPYRIGHT-library.html" "$licenses/rust-standard-library/"
+cp -r "$rust_docs/licenses" "$licenses/rust-standard-library/"
+cargo about generate --locked --fail \
+    --manifest-path keygen-rs/Cargo.toml --target x86_64-unknown-linux-gnu \
+    --output-file "$licenses/rust.txt" ci/release/licenses.hbs
+cmake -S . -B "$build_dir" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
+    -DACPP_TARGETS=generic -DXCHPLOT2_BUILD_CUDA="$build_cuda" \
+    -DCMAKE_CUDA_ARCHITECTURES='50-real;52-real;60-real;61-real;70-real;75-real;80-real;86-real;89-real;90-real;100-real;120' \
+    -DCMAKE_CUDA_RUNTIME_LIBRARY=Static \
+    -DXCHPLOT2_PACKAGE=ON -DXCHPLOT2_PACKAGE_GPU="$gpu" \
+    -DXCHPLOT2_LICENSE_DIR="$licenses" -DXCHPLOT2_RUNTIME_DIR="$runtime"
+cmake --build "$build_dir" --parallel "${CMAKE_BUILD_PARALLEL_LEVEL:-2}"
+ACPP_VISIBILITY_MASK=omp ctest --test-dir "$build_dir" --output-on-failure --no-tests=error \
+    -R '^(bench_stats_test|numa_topology_test|temp_file_test|spill_engine_test|spill_coverage_test|host_guard_test|host_spill_policy_test|vram_budget_test|cli_host_test|pipeline_control_test|plot_file_parity|sycl_twophase_budget_test|solver_filter_parity)$'
+cpack --config "$build_dir/CPackConfig.cmake" -B "$build_dir/dist"

--- a/scripts/test/gpu-ci.py
+++ b/scripts/test/gpu-ci.py
@@ -64,6 +64,7 @@ def tier_caps(info, physical_mib=0):
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("build", type=Path)
+    parser.add_argument("--binary", type=Path, help="Test an extracted release executable")
     parser.add_argument("--backend", choices=MASKS, required=True)
     parser.add_argument("--suite", choices=("quick", "vram", "physical"), default="quick")
     parser.add_argument("--physical-vram-mib", type=int, default=0)
@@ -80,7 +81,7 @@ def main():
     if not scratch.is_dir():
         parser.error("--scratch must be an existing directory on real disk")
     env["TMPDIR"] = str(scratch)
-    binary = build / "tools/xchplot2/xchplot2"
+    binary = args.binary.resolve() if args.binary else build / "tools/xchplot2/xchplot2"
 
     def run(label, command, run_env=None, cwd=None):
         print(f"Running {label}", flush=True)

--- a/scripts/test/release.py
+++ b/scripts/test/release.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Exercise an extracted binary archive without a compiler or GPU toolkit."""
+import argparse
+import hashlib
+import os
+import pathlib
+import subprocess
+import tarfile
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=pathlib.Path)
+    parser.add_argument("--sycl-probe", type=pathlib.Path,
+                        help="Matching build/tools/sanity/hellosycl executable")
+    args = parser.parse_args()
+    digest = hashlib.sha256()
+    with args.archive.open("rb") as archive:
+        for block in iter(lambda: archive.read(1024 * 1024), b""):
+            digest.update(block)
+    checksum = pathlib.Path(str(args.archive) + ".sha256").read_text().split()
+    assert checksum == [digest.hexdigest(), args.archive.name], "Archive checksum mismatch"
+    with tempfile.TemporaryDirectory(prefix="xchplot2-release-") as temporary:
+        work = pathlib.Path(temporary)
+        with tarfile.open(args.archive) as archive:
+            archive.extractall(work, filter="data")
+        packages = list(work.iterdir())
+        assert len(packages) == 1 and packages[0].is_dir(), "Expected one package directory"
+        package = packages[0]
+        for name in ("BUILDINFO.txt", "README.txt", "licenses/LICENSE", "licenses/rust.txt",
+                     "licenses/pos2-chip.txt", "licenses/fse.txt", "licenses/aes.txt",
+                     "licenses/adaptivecpp.txt", "licenses/llvm.txt",
+                     "licenses/rust-standard-library/COPYRIGHT-library.html"):
+            assert (package / name).stat().st_size > 0, f"Missing or empty {name}"
+        binary = package / "bin/xchplot2"
+        subprocess.run([binary, "--help", "--config", os.devnull], check=True, timeout=30)
+        # The existing probe runs a real SSCP kernel through the packaged JIT.
+        # Its build-tree RPATH cannot resolve inside the clean runtime image.
+        if args.sycl_probe:
+            env = dict(os.environ, ACPP_VISIBILITY_MASK="omp", LD_LIBRARY_PATH=str(package / "lib"))
+            subprocess.run([args.sycl_probe.resolve()], env=env, check=True, timeout=180)
+            print("Packaged SYCL JIT check passed")
+        plot_id, memo = "ab" * 32, "00" * 112
+        manifest = work / "cpu.tsv"
+        manifest.write_text(f"18 2 0 0 0 {plot_id} {memo} . cpu.plot2\n")
+        subprocess.run([binary, "batch", manifest, "--devices", "cpu", "--cpu-workers", "2",
+                        "--config", os.devnull],
+                       cwd=work, check=True, timeout=180)
+        subprocess.run([binary, "verify", work / "cpu.plot2", "--full", "--trials", "100",
+                        "--config", os.devnull],
+                       check=True, timeout=180)
+        print("Release archive: extraction, CLI, CPU plotting, and full proofs passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/host/BatchPlotter.cpp
+++ b/src/host/BatchPlotter.cpp
@@ -3403,7 +3403,6 @@ BatchStrategy select_strategy(
         return BatchStrategy::WorkQueue;
     }
 
-    std::uint64_t const tiny_peak  = streaming_tiny_peak_bytes(inputs.k);
     std::uint64_t       min_vram   = UINT64_MAX;
     int                 min_dev    = -1;
     for (int id : inputs.device_ids) {
@@ -3419,6 +3418,7 @@ BatchStrategy select_strategy(
         return BatchStrategy::WorkQueue;
     }
 
+    std::uint64_t const tiny_peak = streaming_tiny_peak_bytes(inputs.k);
     if (min_vram < tiny_peak) {
         if (reason_out) {
             *reason_out =

--- a/src/host/GpuBufferPool.cpp
+++ b/src/host/GpuBufferPool.cpp
@@ -981,8 +981,8 @@ namespace {
 //
 // Baseline set at 256 MB at k=28 (a touch over CUB's typical scratch
 // on sm_89 to keep headroom on NVIDIA cards near the threshold) and
-// scaled 2× per +k step (linear in cap, matching how CUB's actual
-// DeviceRadixSort scratch grows). The returned adjustment is
+// scaled by match capacity (including overflow), matching how CUB's actual
+// DeviceRadixSort scratch grows. The returned adjustment is
 // `max(0, runtime_sort_scratch - baseline)`, so NVIDIA hosts whose
 // runtime scratch is at or below the baseline see no change in
 // predicted peak.
@@ -1010,10 +1010,8 @@ inline size_t streaming_sort_scratch_adjustment(int k)
         cap_for_k, 0, 2 * k, q);
     size_t const actual = std::max(s_pairs, s_keys);
 
-    int const dk = k - 28;
-    size_t baseline = cub_baseline_at_k28_bytes;
-    if (dk > 0)      baseline <<= dk;
-    else if (dk < 0) baseline >>= -dk;
+    size_t const baseline = (cub_baseline_at_k28_bytes >> 20) * cap_for_k
+        / (match_phase_capacity(28, 2) >> 20);
 
     return (actual > baseline) ? (actual - baseline) : 0;
 }

--- a/src/host/VramBudget.hpp
+++ b/src/host/VramBudget.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "PoolSizing.hpp"
+
 #include <cstdint>
 #include <charconv>
 #include <limits>
@@ -36,8 +38,15 @@ inline std::uint64_t streaming_base_peak_bytes(int k, StreamingTier tier)
         case StreamingTier::Tiny:    mib = 1100; break;
         case StreamingTier::Pinned:  mib = 1150; break;
     }
-    auto const bytes = mib << 20;
-    return k < 28 ? bytes >> (28 - k) : bytes << (k - 28);
+    // Capacity includes the section overflow allowance, which does not scale
+    // as 2^k. Tiny and Pinned also retain a fixed 24 MiB partition tile.
+    std::uint64_t const fixed_mib =
+        tier == StreamingTier::Tiny || tier == StreamingTier::Pinned ? 24 : 0;
+    int const section_bits = k < 28 ? 2 : k - 26;
+    auto const cap = match_phase_capacity(k, section_bits);
+    auto const reference_mib = match_phase_capacity(28, 2) >> 20;
+    return ((mib - fixed_mib) * cap + reference_mib - 1) / reference_mib
+        + (fixed_mib << 20);
 }
 
 inline bool vram_fits(std::uint64_t free, std::uint64_t peak,

--- a/tools/parity/vram_budget_test.cpp
+++ b/tools/parity/vram_budget_test.cpp
@@ -23,6 +23,12 @@ int main()
             assert(vram_scratch_budget(peak + buffer + 812, peak, buffer) == 812);
         }
     }
+    // Small plots retain the full partition tile and proportionally more
+    // overflow capacity. Scaling the k=28 byte count alone underestimates both.
+    assert(streaming_base_peak_bytes(22, StreamingTier::Tiny) >= 42 * MiB);
+    assert(streaming_base_peak_bytes(22, StreamingTier::Pinned) >= 42 * MiB);
+    assert(streaming_base_peak_bytes(26, StreamingTier::Plain) >= 1848 * MiB);
+    assert(streaming_base_peak_bytes(28, StreamingTier::Tiny) == 1100 * MiB);
     // Target card capacities after a representative 390 MiB context. The
     // picker must include the buffer exactly once and stop at Tiny.
     for (auto [gib, expected] : std::array{


### PR DESCRIPTION
Package Linux x86-64 SYCL archives for NVIDIA, AMD, and Intel with relocatable AdaptiveCpp/JIT runtimes, explicit compiler and GPU targets, dependency licenses, source/toolchain metadata, and SHA-256 checksums. Reuse AdaptiveCpp deployment support and keep system drivers outside the archives. Tagged builds create draft releases for hardware qualification.

Supporting fixes keep CPU-only multiworker batches out of GPU budget queries, include actual streaming overflow capacity in VRAM admission, and remove an unused production CLVM dependency from key generation. The Windows evaluation documents the remaining upstream toolchain, backend memory-query, and hardware qualification gaps for AMD and Intel.

Validation:
- All three GitHub-hosted release builds passed host tests, clean Ubuntu 24.04 runtime/JIT checks, CPU plotting, and full proofs.
- The exact hosted NVIDIA archive passed 54 CPU byte comparisons across k=18–28 and every tier/spill variant, each with 100 full-proof challenges.
- The exact hosted Intel archive, using the documented B580 driver settings and a 1024 MiB VRAM margin, passed 14 cases covering every k=22 tier/spill variant and k=28 plain plus disk variants, each with CPU byte comparisons and 100 full-proof challenges.
- A targeted NVIDIA k=28 Compute Sanitizer initcheck reported zero errors; the instrumented output matched the retained CPU reference and passed 100 full-proof challenges.
- Both hosted archives passed real CLI cancellation, key-preserving resume, publication failure/recovery, and parallel CPU plotting.

AMD hardware was unavailable. An initial locally built NVIDIA archive produced one k=28 byte mismatch, and initial Intel parallel queue tests hung; neither issue recurred in subsequent qualification, but their causes remain unresolved. Keep this draft until those findings and remaining hardware coverage are accepted for release.
